### PR TITLE
Попытка исправить все артефакты с текстурами

### DIFF
--- a/res/shaders/shader.fs
+++ b/res/shaders/shader.fs
@@ -7,7 +7,7 @@ in vec2 TexCoord;
 in float TexIndex;
 
 // Текстурные сэмплеры
-uniform sampler2DRect textures[16];
+uniform sampler2D textures[16];
 
 void main()
 {

--- a/src/client/graphics/Font.cpp
+++ b/src/client/graphics/Font.cpp
@@ -42,7 +42,7 @@ Font::Font(const std::string &path, int size)
     // Так как мы узнали ширину и высоту, то можем заранее создать текстуру для всех глифов
     unsigned int textureId;
     glGenTextures(1, &textureId);
-    glBindTexture(GL_TEXTURE_RECTANGLE, textureId);
+    glBindTexture(GL_TEXTURE_2D, textureId);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
     glTextureParameteri(textureId, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/src/client/graphics/SpriteBatch.cpp
+++ b/src/client/graphics/SpriteBatch.cpp
@@ -105,6 +105,31 @@ void SpriteBatch::end()
     delete[] ids;
 }
 
+// This function makes our rect a bit smaller.
+// It helps to prevent strange artifacts with textures.
+static FloatRect prepareRect(IntRect rect)
+{
+    float offset = 0.5f;
+
+    auto left = (float) rect.getLeft();
+    auto bottom = (float) rect.getBottom();
+    auto width = (float) rect.getWidth();
+    auto height = (float) rect.getHeight();
+
+    left += glm::sign(width) * offset;
+    bottom += glm::sign(height) * offset;
+
+    width = glm::sign(width) * (std::abs(width) - 2 * offset);
+    height = glm::sign(height) * (std::abs(height) - 2 * offset);
+
+    return {left, bottom, width, height};
+}
+
+static glm::vec2 toTexCoords(Texture& texture, float x, float y)
+{
+    return {(float) x / texture.getWidth(), (float) y / texture.getHeight()};
+}
+
 void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
 {
     // Actually we draw nothing here. In this method we just collect the sprites to draw them later
@@ -157,15 +182,14 @@ void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
     }
     auto &set = resultSet->second;
 
-    // We need this offset to prevent strange artifacts with textures
-    float texOffset = 0.1f;
+    FloatRect r = prepareRect(rect);
 
     set.insert(
             {
                     {
                             glm::vec3(quadPos, 0.f), // bottom left
                             sprite.getColor(),
-                            glm::vec2(rect.getLeft(), rect.getBottom()), texId
+                            toTexCoords(texture, r.getLeft(), r.getBottom()), texId
                     }, order
             });
     set.insert(
@@ -173,7 +197,7 @@ void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
                     {
                             glm::vec3(quadPos + glm::vec2(w, 0.f), 0.f), // bottom right
                             sprite.getColor(),
-                            glm::vec2(rect.getLeft() + rect.getWidth() - texOffset, rect.getBottom()),
+                            toTexCoords(texture, r.getLeft() + r.getWidth(), r.getBottom()),
                             texId
                     }, order
             });
@@ -182,8 +206,7 @@ void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
                     {
                             glm::vec3(quadPos + glm::vec2(w, h), 0.f), // top right
                             sprite.getColor(),
-                            glm::vec2(rect.getLeft() + rect.getWidth() - texOffset,
-                                      rect.getBottom() + rect.getHeight() - texOffset),
+                            toTexCoords(texture, r.getLeft() + r.getWidth(), r.getBottom() + r.getHeight()),
                             texId
                     }, order
             });
@@ -192,7 +215,7 @@ void SpriteBatch::draw(const Sprite &sprite, int layer, int order)
                     {
                             glm::vec3(quadPos + glm::vec2(0.f, h), 0.f), // top left
                             sprite.getColor(),
-                            glm::vec2(rect.getLeft(), rect.getBottom() + rect.getHeight() - texOffset),
+                            toTexCoords(texture, r.getLeft(), r.getBottom() + r.getHeight()),
                             texId
                     }, order
             });

--- a/src/client/graphics/Texture.h
+++ b/src/client/graphics/Texture.h
@@ -31,7 +31,7 @@ public:
 
     int getHeight() const;
 
-    static Texture create(const std::string &path, unsigned int type = GL_TEXTURE_RECTANGLE);
+    static Texture create(const std::string &path, unsigned int type = GL_TEXTURE_2D);
 };
 
 

--- a/src/scene/systems/RenderSystem.cpp
+++ b/src/scene/systems/RenderSystem.cpp
@@ -61,8 +61,8 @@ void RenderSystem::draw()
                 auto &worldMapComponent = view.get<WorldMapComponent>(entity);
                 auto transformComponent = Hierarchy::computeTransform({entity, &m_registry});
 
-                int currentX = (int) std::round(cameraTransform.position.x / ((float) worldMapComponent.tileSize * transformComponent.scale.x));
-                int currentY = (int) std::round(cameraTransform.position.y / ((float) worldMapComponent.tileSize * transformComponent.scale.y));
+                int currentX = (int) std::floor(cameraTransform.position.x / ((float) worldMapComponent.tileSize * transformComponent.scale.x));
+                int currentY = (int) std::floor(cameraTransform.position.y / ((float) worldMapComponent.tileSize * transformComponent.scale.y));
 
                 for (int y = currentY + worldMapComponent.renderRadius - 1; y >= currentY - worldMapComponent.renderRadius + 1; y--)
                 {

--- a/src/scripts/WorldMapScript.h
+++ b/src/scripts/WorldMapScript.h
@@ -90,7 +90,7 @@ public:
         Window &window = Window::getInstance();
         float radius = std::max(window.getWidth(), window.getHeight()) / 2;
         float scale = std::max(m_worldTransform->scale.x, m_worldTransform->scale.y);
-        m_worldMap->renderRadius = radius / (scale * m_worldMap->tileSize) + 2;
+        m_worldMap->renderRadius = radius / (scale * m_worldMap->tileSize) + 3;
     }
 };
 


### PR DESCRIPTION
Вроде мне удалось исправить все те странные артефакты с текстурами: полосы между тайлами, куски других символов в тексте и прочее (в зависимости от видеокарты и драверов глитчи могли быть разные). Запилил небольшую функцию, которая перед отрисовкой уменьшает на полпикселя текстурные координаты, это помогает избежать всех неверных округлений при наложении текстур. Протестил на всех машинах, которые мне доступны, кажись этот хак работает.