### PR TITLE
entt: Add a library 'entt'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,8 @@ add_subdirectory(libs/stb_image)
 add_subdirectory(libs/glm)
 add_subdirectory(libs/freetype)
 add_subdirectory(libs/miniaudio)
+add_subdirectory(libs/entt)
 
-set(PROJECT_LIBS glad glfw OpenGL::GL stb_image glm freetype miniaudio)
+set(PROJECT_LIBS glad glfw OpenGL::GL stb_image glm freetype miniaudio entt)
 
 target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})
-
-target_include_directories(${PROJECT_NAME} PUBLIC libs/entt/include)

--- a/libs/entt/CMakeLists.txt
+++ b/libs/entt/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 project(entt)
 
-target_include_directories(entt PUBLIC include)
+add_library(entt INTERFACE)
+target_include_directories(entt INTERFACE include)


### PR DESCRIPTION
We were including the directory itself.
I think it's better to add an INTERFACE library
and include the includes into it.